### PR TITLE
0.0.205; https://opentelemetry.io/docs/specs/otel/compatibility/loggi…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jgithub/ts-gist-pile",
-  "version": "0.0.204",
+  "version": "0.0.205",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jgithub/ts-gist-pile",
-      "version": "0.0.204",
+      "version": "0.0.205",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@types/uuid": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jgithub/ts-gist-pile",
-  "version": "0.0.204",
+  "version": "0.0.205",
   "description": "tired of finding this on stackoverflow",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
…ng_trace_context/#overview non-otlp JSON logs use trace_id, not traceId