### PR TITLE
0.0.331 Add optional value field to Happening interface

### DIFF
--- a/dist/happening/Happening.d.ts
+++ b/dist/happening/Happening.d.ts
@@ -52,5 +52,6 @@ export interface Happening {
     traceId?: string;
     severity?: string;
     duration?: number;
+    value?: number;
     hostname?: string;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jgithub/ts-gist-pile",
-  "version": "0.0.330",
+  "version": "0.0.331",
   "description": "tired of finding this on stackoverflow",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/happening/Happening.ts
+++ b/src/happening/Happening.ts
@@ -76,5 +76,6 @@ export interface Happening {
   traceId?: string,               // OTel: trace_id, CloudEvents: traceparent extension
   severity?: string,              // OTel: severity_text
   duration?: number,
+  value?: number,               // General-purpose numeric measurement (null implies count of 1)
   hostname?: string
 }


### PR DESCRIPTION
General-purpose numeric measurement field (nullable). When null, the happening implies a count of 1. When set, carries a measurement like temperature, queue depth, or batch size alongside the event.